### PR TITLE
Fix Hugo module declaration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/danielfdickinson/image-handling-mod-hugo-dfd/exampleSite
+module github.com/danielfdickinson/image-handling-mod-demo
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.0.0-20230331134055-5f491176decf h1:SSo4+hDdqj+XXIQ2cShULYJKZxyKlgdr15QUcNtulv4=
 github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.0.0-20230331134055-5f491176decf/go.mod h1:h+vNqbDFVmrcnlUq1GsWtKS3HWw7wLDqM1PahGQjSOY=
-github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.3-0.20220801020716-c28b4bdbab3e/go.mod h1:ajYr1qZHU5FJloKLT9rF8jSzKhuv5uSzQ/kA5M1vsY8=
 github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.4.4-0.20221028020841-ed00480e7085 h1:AJc8eN55ayWkvSR1Nw39fUIXeeEsAuuwLykEPZuSC2c=
 github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.4.4-0.20221028020841-ed00480e7085/go.mod h1:6NZ/CEGWWMq2Xj1QMVmjUlWjNVfAinHndltjTdzIG7o=


### PR DESCRIPTION
When used as a site the module declaration didn't really matter, but when
used as a module it must match the git repo.